### PR TITLE
Enable detection of touch events which trigger navigation

### DIFF
--- a/xwalk.js
+++ b/xwalk.js
@@ -831,7 +831,6 @@ function addEventOffset (e) {
     }
 
     function scrollableTouchStart (e) {
-        e.preventDefault ();
         if (e.touches.length)
             touchY = e.touches[0].pageY;
     }


### PR DESCRIPTION
Because touchstart events were being ignored (via preventDefault()),
clicks on navigation elements in the side menu were being swallowed
when the scrollbars were active.

This just allows touchstart events to be detected.

Tested on Chrome desktop and Chrome on Nexus 7, and appears to
work on both.

Fixes https://crosswalk-project.org/jira/browse/XWALK-863
