### PR TITLE
Fix syntax error in generate.css.php

### DIFF
--- a/generate.css.php
+++ b/generate.css.php
@@ -52,7 +52,7 @@ body {
     background: red;
     color: red;
 }
-<?
+<?php
     exit;
 }
 
@@ -144,3 +144,4 @@ touch ($basename.'.css', $scss['mtime']);
 touch ($basename.'.css.map', $scss['mtime']);
 
 success ();
+?>


### PR DESCRIPTION
Newest php versions seems to be more picky on closing
correctly tags as well as using <?php when appropriate.
