### PR TITLE
Execute eval from the "window" context (this == window) vs. the context ...

### DIFF
--- a/xwalk.js
+++ b/xwalk.js
@@ -538,7 +538,7 @@ function content_response (e) {
     var scriptlets = content.getElementsByTagName ('script');
     div.appendChild (content);
     Array.prototype.forEach.call (scriptlets, function (script) {
-        eval (script.innerHTML);
+        eval.call (window, script.innerHTML);
     });
 
     /*


### PR DESCRIPTION
...of content_response

Signed-off-by: jketreno james.p.ketrenos@intel.com
