### PR TITLE
Fix broken site navigation when using Safari on Mac OS X

### DIFF
--- a/xwalk.js
+++ b/xwalk.js
@@ -141,8 +141,8 @@ function activateColumn (name) {
     page.appendChild (column);
 
     column.classList.remove ('hidden');
-    column.style.position.left = '0px';
-    column.style.position.top = top_menu.offsetHeight + 'px';
+    column.style.left = '0px';
+    column.style.top = top_menu.offsetHeight + 'px';
 
     _onResize ();
 }


### PR DESCRIPTION
I tracked this down to two lines which referred to style.position.left and style.position.top, which should be style.left and style.top. Safari seems to have a habit of failing silently in these situations, which resulted in the navigation breaking.

I've tested on Safari on iPad, which was exhibiting the same bug.

Fixes https://crosswalk-project.org/jira/browse/XWALK-903
