### PR TITLE
Don't break external links when Google Analytics is blocked or not loaded

### DIFF
--- a/xwalk.js
+++ b/xwalk.js
@@ -944,9 +944,7 @@ function subMenuClick (e) {
 
 function trackAbandonLink (e) {
     var href = e.currentTarget.getAttribute ('href');
-    e.preventDefault ();
-//        target = e.currentTarget.getAttribute ('target');
-    if (ga) {
+    if (ga && ga.hasOwnProperty ('loaded') && ga.loaded === true) {
         ga ('send', 'event', {
             'eventCategory': 'wiki-anchor',
             'eventAction': 'click',
@@ -956,6 +954,7 @@ function trackAbandonLink (e) {
                 window.location.href = href;
             }
         });
+        e.preventDefault ();
     }
 }
 


### PR DESCRIPTION
This is a fix for https://crosswalk-project.org/jira/browse/XWALK-879

The fix is based on https://www.domsammut.com/code/workaround-for-when-the-hitcallback-function-does-not-receive-a-response-analytics-js

I changed it to `preventDefault()` and rely on `hitCallback` only when GA is actually loaded.
