### PR TITLE
Fix invalid call context in IE

### DIFF
--- a/xwalk.js
+++ b/xwalk.js
@@ -545,8 +545,8 @@ function content_response (e) {
     while (div.firstChild)
         div.removeChild (div.firstChild);
 
-    var scriptlets = content.getElementsByTagName ('script');
     div.appendChild (content);
+    var scriptlets = content.getElementsByTagName ('script');
     Array.prototype.forEach.call (scriptlets, function (script) {
         eval.call (window, script.innerHTML);
     });


### PR DESCRIPTION
The element collection is invalidated once it is added to the div item, so
make the call to getElementsByTag _after_ the content is added to the div.

Signed-off-by: jketreno james.p.ketrenos@intel.com
