### PR TITLE
Ensure cached wiki file name matches webhook html_url

### DIFF
--- a/http.php
+++ b/http.php
@@ -171,7 +171,7 @@ class CachingHttpClient {
 
         // only check the file if the cache is turned on
         if ($caching_on) {
-            $key = sha1 ($url);
+            $key = sha1 (strtolower (urldecode ($url)));
             $path = $this->cache_dir . $key . '.html';
 
             $mtime = @filemtime ($path);

--- a/regen.php
+++ b/regen.php
@@ -43,7 +43,8 @@ if ($payload) {
             // different actions right now, and don't really want to
             // create the same HTTP client in multiple places;
             // so this is a quick workaround
-            $key = sha1 ($page->html_url);
+            $normalised_url = strtolower (urldecode ($page->html_url));
+            $key = sha1 ($normalised_url);
             $page_cached = 'wiki' . DIRECTORY_SEPARATOR . $key . '.html';
             @unlink ($page_cached);
         }


### PR DESCRIPTION
Previously, cached wiki pages were not being removed in response
to the webhook as there was a mismatch between the filename hash
produced by the caching HTTP client and the hash produced from
the html_url in the data posted from github when the wiki changed.

This patch normalises the cache filename in both cases
(lowercase and with special characters decoded from the URL)
so that they match correctly.
