### PR TITLE
Update URLs pointing to download.01.org.

### DIFF
--- a/contribute/99-Channels-Viewer.php
+++ b/contribute/99-Channels-Viewer.php
@@ -62,7 +62,7 @@
     // insert one row in the table for a particular OS
     var insertOSRow = function (OS, arch, channel, branch, sha, version,
     chromium_version, chromium_sha, blink_sha) {
-        var download_url = getXwalkDownloadUrl(OS, arch, channel);
+        var download_url = getXwalkDownloadUrl(OS, arch, channel, version);
 
         var chromium_commit_url = 'https://github.com/crosswalk-project/' +
                                   'chromium-crosswalk/commit/' + chromium_sha;

--- a/documentation/20-Downloads.php
+++ b/documentation/20-Downloads.php
@@ -101,7 +101,7 @@
     <p>* - note that release notes are only produced for stable and beta
     versions.</p>
 
-    <p><a href="https://download.01.org/crosswalk/releases/">More downloads...</a></p>
+    <p><a href="https://download.01.org/crosswalk/releases/crosswalk/">More downloads...</a></p>
 
     <h2>Release channels</h2>
 

--- a/documentation/80-APIs.md
+++ b/documentation/80-APIs.md
@@ -52,7 +52,7 @@ The following standard APIs are supported by Crosswalk on both Android and Tizen
 # Experimental APIs
 In addition to the standard APIs, Crosswalk provides additional experimental or emerging standards APIs to further support building a native application experience using web platform technologies.
 
-* [Presentation API] (http://webscreens.github.io/presentation-api/) - Access external displays from within web applications. For more information see the [Presentation API developer documentation] (https://github.com/crosswalk-project/crosswalk-website/wiki/Presentation-api-manual). Introduced in [Crosswalk 3.32.49.0] (https://download.01.org/crosswalk/releases/).
+* [Presentation API] (http://webscreens.github.io/presentation-api/) - Access external displays from within web applications. For more information see the [Presentation API developer documentation] (https://github.com/crosswalk-project/crosswalk-website/wiki/Presentation-api-manual). Introduced in [Crosswalk 3.32.49.0] (https://download.01.org/crosswalk/releases/crosswalk/).
 * [Device Capabilities] (http://www.w3.org/2012/sysapps/device-capabilities/) - Retrieve information about the underlaying system.
 * [Raw Sockets] (http://www.w3.org/TR/raw-sockets/) - Raw TCP and UDP sockets for client and server sides.
 

--- a/documentation/Getting_Started/10-Host_setup.md
+++ b/documentation/Getting_Started/10-Host_setup.md
@@ -313,7 +313,7 @@ To get Crosswalk Android for x86, run these commands in a bash shell:
 
     # the `-k` option prevents curl from failing due to SSL
     # certificate verification errors.
-    $ curl -k https://download.01.org/crosswalk/releases/android-x86/stable/crosswalk-${XWALK-STABLE-ANDROID-X86}-x86.zip -o crosswalk-${XWALK-STABLE-ANDROID-X86}-x86.zip
+    $ curl -k https://download.01.org/crosswalk/releases/crosswalk/android/stable/${XWALK-STABLE-ANDROID-X86}/x86/crosswalk-${XWALK-STABLE-ANDROID-X86}-x86.zip -o crosswalk-${XWALK-STABLE-ANDROID-X86}-x86.zip
 
     # unzip the Crosswalk Android archive
     $ unzip crosswalk-${XWALK-STABLE-ANDROID-X86}-x86.zip

--- a/documentation/Getting_Started/15-Tizen_target_setup.md
+++ b/documentation/Getting_Started/15-Tizen_target_setup.md
@@ -115,8 +115,8 @@ Once the manager has loaded, ensure that the drop-down menu in the top-left of t
   # be slightly different from "sh-4.1#")
 
   # download and install the Crosswalk Tizen and Tizen emulator rpms
-  sh-4.1# curl https://download.01.org/crosswalk/releases/tizen-mobile/stable/crosswalk-${XWALK-STABLE-TIZEN-X86}-0.i586.rpm -o tz-xwalk.rpm
-  sh-4.1# curl https://download.01.org/crosswalk/releases/tizen-mobile/stable/crosswalk-emulator-support-${XWALK-STABLE-TIZEN-X86}-0.i586.rpm -o tz-xwalk-emulator.rpm
+  sh-4.1# curl https://download.01.org/crosswalk/releases/crosswalk/tizen-mobile/stable/${XWALK-STABLE-TIZEN-X86}/crosswalk-${XWALK-STABLE-TIZEN-X86}-0.i586.rpm -o tz-xwalk.rpm
+  sh-4.1# curl https://download.01.org/crosswalk/releases/crosswalk/tizen-mobile/stable/${XWALK-STABLE-TIZEN-X86}/crosswalk-emulator-support-${XWALK-STABLE-TIZEN-X86}-0.i586.rpm -o tz-xwalk-emulator.rpm
   sh-4.1# rpm -ih tz*.rpm
   </pre>
 </li>

--- a/documentation/Tizen_IVI_extensions/10-Host_and_target_setup.md
+++ b/documentation/Tizen_IVI_extensions/10-Host_and_target_setup.md
@@ -96,7 +96,7 @@ Once you have a target ready, you can install Crosswalk on it:
 
 2.  From the shell on the target, download the Crosswalk package:
 
-        curl -O https://download.01.org/crosswalk/releases/tizen-ivi/canary/crosswalk-5.32.87.0-0.i586.rpm
+        curl -O https://download.01.org/crosswalk/releases/crosswalk/tizen-ivi/canary/5.32.87.0/crosswalk-5.32.87.0-0.i586.rpm
 
     And install it:
 

--- a/utils.js
+++ b/utils.js
@@ -50,31 +50,27 @@ function getXwalkDownloadUrl(OS, arch, channel, version) {
         file_prefix += "emulator-support-";
     }
 
-    var download_url = 'https://download.01.org/crosswalk/releases/' + OS;
+    var download_url = 'https://download.01.org/crosswalk/releases/crosswalk/'
+                     + OS + '/' + channel + '/' + version + '/';
 
-    if (OS === "android") {
-        download_url += "-" + arch
+    // android: crosswalk-beta >= 5.34.104.1 and crosswalk-canary >= 6.34.106.0
+    // will be architecture-independent, so once we move to those we need to
+    // remove |arch| from here and the checks below.
+    download_url += (OS === "android" ? arch + '/' : '') + file_prefix + version;
+
+    if (OS === "android" && arch === "x86") {
+        download_url += "-x86.zip";
     }
-
-    download_url += "/" + channel + "/";
-
-    if (version) {
-        download_url += file_prefix + version;
-
-        if (OS === "android" && arch === "x86") {
-            download_url += "-x86.zip";
-        }
-        else if (OS === "android" && arch === "arm") {
-            download_url += "-arm.zip";
-        }
-        // as of tizen-mobile 5.32.88.0, suffix changed to 686
-        else if (OS === "tizen-ivi" || (OS === "tizen-mobile" && channel === "canary")) {
-            download_url += "-0.i686.rpm";
-        }
-        // older tizen-mobile
-        else {
-            download_url += "-0.i586.rpm";
-        }
+    else if (OS === "android" && arch === "arm") {
+        download_url += "-arm.zip";
+    }
+    // as of tizen-mobile 5.32.88.0, suffix changed to 686
+    else if (OS === "tizen-ivi" || (OS === "tizen-mobile" && channel === "canary")) {
+        download_url += "-0.i686.rpm";
+    }
+    // older tizen-mobile
+    else {
+        download_url += "-0.i586.rpm";
     }
 
     return download_url;


### PR DESCRIPTION
There has been a big reorganization as discussed in 
https://lists.crosswalk-project.org/pipermail/crosswalk-dev/2014-March/001215.html. 
In summary, a URL such as

  /releases/android-x86/canary/crosswalk-5.6.7.8-x86.zip

is now hosted at

  /releases/crosswalk/android/canary/5.6.7.8/x86/crosswalk-5.6.7.8-x86.zip

Similarly, Tizen RPMs have undergone the following change:

  /releases/tizen-mobile/canary/crosswalk-5.6.7.8-0-i686.rpm

is now

  /releases/crosswalk/tizen-mobile/canary/5.6.7.8/crosswalk-5.6.7.8-0-i686.rpm

Additionally, the Android URLs are going to change again starting from the 
next canary and next beta -- the main zip files are going to be 
architecture-independent, like this:

  /releases/crosswalk/android/canary/5.6.7.9/crosswalk-5.6.7.9.zip

This adjustment has not been done because these new binaries have not been 
produced yet, though.

The new layout also allows us to simplify getXwalkDownloadUrl() by making the
|version| argument mandatory, since each binary is in a separate directory
now.
