### PR TITLE
Update Android getting started instructions for new folder layout

### DIFF
--- a/documentation/Getting_Started/10-Windows_host_setup.md
+++ b/documentation/Getting_Started/10-Windows_host_setup.md
@@ -95,12 +95,6 @@ To get Crosswalk Android for x86:
 
 2.  Unzip it. You should now have a `C:\${XWALK-STABLE-ANDROID-X86}-x86` directory.
 
-3.  `cd ${XWALK-STABLE-ANDROID-X86}-x86`
-
-4.  You should see an `xwalk_app_template.tar.gz` file. Unpack it with WinZip or similar.
-
-You should now have a `crosswalk-${XWALK-STABLE-ANDROID-X86}-x86\xwalk_app_template` directory.
-
 ### Verify your environment
 
 Check that you have installed the tools properly by running these commands:

--- a/documentation/Getting_Started/11-Linux_host_setup.md
+++ b/documentation/Getting_Started/11-Linux_host_setup.md
@@ -107,14 +107,6 @@ To get Crosswalk Android for x86:
 
 2.  Unzip it. You should now have a `${XWALK-STABLE-ANDROID-X86}-x86` directory.
 
-3.  `cd ${XWALK-STABLE-ANDROID-X86}-x86`
-
-4.  You should see an `xwalk_app_template.tar.gz` file. Unpack it:
-
-        tar zxvf xwalk_app_template.tar.gz
-
-You should now have a `crosswalk-${XWALK-STABLE-ANDROID-X86}-x86/xwalk_app_template` directory.
-
 ### Verify your environment
 
 Check that you have installed the tools properly by running these commands:

--- a/documentation/Getting_Started/30-Run_on_Android.md
+++ b/documentation/Getting_Started/30-Run_on_Android.md
@@ -4,10 +4,9 @@ The Crosswalk Android download contains a Python script which can be used to mak
 
 Once you have downloaded and unpacked Crosswalk Android, create an `apk` file for your application as follows:
 
-1.  Go to the `xwalk_app_template` directory inside the unpacked Crosswalk Android directory:
+1.  Go to the unpacked Crosswalk Android directory:
 
         > cd ${XWALK-STABLE-ANDROID-X86}-x86
-        > cd xwalk_app_template
 
 2.  Run the `make_apk.py` script with Python as follows:
 


### PR DESCRIPTION
There is no longer an xwalk_app_template.tar.gz file to unpack
after downloading Crosswalk Android (the top-level directory
after you've unpacked is the app template).

Fix the instructions, removing all references to this second
unpacking stage.
