### PR TITLE
Remove unused/unavailable image file references

### DIFF
--- a/markdown.scss
+++ b/markdown.scss
@@ -93,7 +93,6 @@ template.css from gollum
     .markdown-body h4:hover a.anchor,
     .markdown-body h5:hover a.anchor,
     .markdown-body h6:hover a.anchor {
-/*      background: url(../images/pin-20.png) no-repeat left center; */
       text-decoration: none;
     }
     .markdown-body h1 tt,
@@ -153,7 +152,6 @@ template.css from gollum
       margin: 15px 0px;
     }
     .markdown-body hr {
-      background: transparent url(../images/dirty-shade.png) repeat-x 0 0;
       border: 0 none;
       color: #ccc;
       height: 4px;


### PR DESCRIPTION
The markdown css file references some image files which don't
exist.

Fixes https://crosswalk-project.org/jira/browse/XWALK-1332
