### PR TITLE
remove() method unsupported on DOM nodes in IE

### DIFF
--- a/xwalk.js
+++ b/xwalk.js
@@ -354,7 +354,7 @@ function generate_wiki_page (page, contents) {
         var right_bar = content.querySelector('#wiki-rightbar');
 
         if (right_bar) {
-          right_bar.remove();
+          right_bar.parentNode.removeChild(right_bar);
         }
     }
 


### PR DESCRIPTION
Use removeChild() from the parent node instead.

(How I wish we'd used jQuery from the beginning...)

Fixes https://crosswalk-project.org/jira/browse/XWALK-1717
