### PR TITLE
[Android] Deprecate xwalk_android_gyp

### DIFF
--- a/contribute/Building_Crosswalk.md
+++ b/contribute/Building_Crosswalk.md
@@ -194,7 +194,10 @@ Chrome's process, so make sure you are
 4.  Configure your setup to generate the Crosswalk projects.
 
         export GYP_GENERATORS='ninja'
-        xwalk_android_gyp
+        python xwalk/gyp_xwalk -Dtarget-arch=ia32 -DOS=android
+
+    If you are targeting ARM, pass `-Dtarget-arch=arm` instead of
+    `-Dtarget-arch=ia32`.
 
 5.  To build xwalk core and runtime shell (for developer testing purposes,
 not for end users), execute:


### PR DESCRIPTION
In M36, android_gyp is still available in upstream, but it is
going to be removed in recent future.
We need to deprecate xwalk_android_gyp together with upstream's
change, and we need to pass '-DOS=android' explicity to it to
generate android building environment.

This change is the prerequisite of the change in crosswalk:
https://github.com/crosswalk-project/crosswalk/pull/2079

BUG=https://crosswalk-project.org/jira/browse/XWALK-1803
