### PR TITLE
[Android] Add --package option for make_apk

### DIFF
--- a/documentation/17-WebRTC.md
+++ b/documentation/17-WebRTC.md
@@ -478,7 +478,8 @@ During the host setup for Android ([Windows](#documentation/getting_started/wind
 
     $ cd crosswalk-${XWALK-STABLE-ANDROID-X86}
 
-    $ python make_apk.py --manifest=xwalk-webrtc/client/manifest.json
+    $ python make_apk.py --package=org.crosswalkproject.example \
+        --manifest=xwalk-webrtc/client/manifest.json
     ...
     An APK for the web application "WebRTC" including the
     Crosswalk Runtime built for x86 was generated successfully,
@@ -546,7 +547,8 @@ If one or both of the client applications isn't working, or you have problems ma
 
 *   To debug the client application running in Crosswalk Android, build the package with the `--enable-remote-debugging` option:
 
-        python make_apk.py --enable-remote-debugging --manifest=...
+        python make_apk.py --package=org.crosswalkproject.example \
+          --enable-remote-debugging --manifest=...
 
     Once the application is launched on the Android target, open Chrome and go to the special "chrome://inspect" address. You should see the Android target listed, along with applications which can be debugged:
 

--- a/documentation/Android_extensions/31-Run_on_Android.md
+++ b/documentation/Android_extensions/31-Run_on_Android.md
@@ -19,7 +19,8 @@ To make Android packages for your project, do the following:
         $ cd $PROJECT_DIR/xwalk-echo-extension-src/lib/crosswalk-${XWALK-STABLE-ANDROID-X86}
 
         # invoke the package builder
-        $ python make_apk.py --enable-remote-debugging --fullscreen \
+        $ python make_apk.py --package=org.crosswalkproject.example \
+            --enable-remote-debugging --fullscreen \
             --manifest=$PROJECT_DIR/xwalk-echo-app/manifest.json \
             --extensions=$PROJECT_DIR/xwalk-echo-extension-src/xwalk-echo-extension/
 

--- a/documentation/Getting_Started/30-Run_on_Android.md
+++ b/documentation/Getting_Started/30-Run_on_Android.md
@@ -10,7 +10,8 @@ Once you have downloaded and unpacked Crosswalk Android, create the `apk` packag
 
 2.  Run the `make_apk.py` script with Python as follows:
 
-        > python make_apk.py --manifest=xwalk-simple/manifest.json
+        > python make_apk.py --package=org.crosswalkproject.example \
+            --manifest=xwalk-simple/manifest.json
 
     This will package the application defined in the specified `manifest.json` file and produce two apk files from it, one for x86 architecture and one for ARM. The apk files will end up in the directory where you ran the script. Each file is given the name set in the manifest, with any filesystem-sensitive characters removed and an architecture identifier ("x86" or "arm") appended. For our example, the output files are `simple_x86.apk` and `simple_arm.apk`.
 

--- a/documentation/Getting_Started/45-Remote_debugging.md
+++ b/documentation/Getting_Started/45-Remote_debugging.md
@@ -25,8 +25,8 @@ Once these pre-requisites have been met, debug your Crosswalk application as fol
 <p>Enable remote debugging by passing a flag to <code>make_apk.py</code> when building the package. For example:</p>
 
 <pre>
-$ python make_apk.py --manifest=/home/me/myapp/manifest.json \
-  --enable-remote-debugging
+$ python make_apk.py --package=org.crosswalkproject.example \
+  --manifest=/home/me/myapp/manifest.json --enable-remote-debugging
 </pre>
 
 </li>

--- a/documentation/Manifest/permissions.md
+++ b/documentation/Manifest/permissions.md
@@ -31,7 +31,8 @@ For example, given the following manifest:
 
 ...and this `make_apk.py` command line:
 
-    python make_apk.py --manifest=manifest.json
+    python make_apk.py --package=org.crosswalkproject.example \
+      --manifest=manifest.json
 
 ...the following `AndroidManifest.xml` permission elements are generated:
 

--- a/documentation/Samples/Hello-world.md
+++ b/documentation/Samples/Hello-world.md
@@ -20,7 +20,8 @@ The quick version is that you can build the Hello World apk with:
 
 ```sh
 > cd <xwalk_app_template directory>
-> python make_apk.py --manifest=<path to crosswalk-samples>/hello_world/manifest.json
+> python make_apk.py --package=org.crosswalkproject.example \
+    --manifest=<path to crosswalk-samples>/hello_world/manifest.json
 ```
 
 `<xwalk_app_template directory>` refers to the directory where you

--- a/documentation/Samples/SIMD.md
+++ b/documentation/Samples/SIMD.md
@@ -31,7 +31,8 @@ The quick version is that you can build the SIMD apk with:
 
 ```sh
 > cd <xwalk_app_template directory>
-> python make_apk.py --manifest=<path to crosswalk-samples>/simd/manifest.json
+> python make_apk.py --package=org.crosswalkproject.example \
+    --manifest=<path to crosswalk-samples>/simd/manifest.json
 ```
 
 `<xwalk_app_template directory>` refers to the directory where you

--- a/documentation/Samples/WebGL.md
+++ b/documentation/Samples/WebGL.md
@@ -21,7 +21,8 @@ The quick version is that you can build the WebGL apk with:
 
 ```sh
 > cd <xwalk_app_template directory>
-> python make_apk.py --manifest=<path to crosswalk-samples>/webgl/manifest.json
+> python make_apk.py --package=org.crosswalkproject.example \
+    --manifest=<path to crosswalk-samples>/webgl/manifest.json
 ```
 
 `<xwalk_app_template directory>` refers to the directory where you


### PR DESCRIPTION
After https://github.com/crosswalk-project/crosswalk/pull/2214,
--package option is mandatory and should be set to the Java package name.
