### PR TITLE
Use a custom gollum with Thin server to improve performance

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -116,10 +116,15 @@ has content in three different markup flavours:
 *   GitHub Markdown (*.md)
 *   Org Mode (*.org)
 
-To install gollum, plus support for these wiki content formats:
+You will also need the thin web server to generate the static site
+using the `site.sh` script and friends.
+
+To install gollum, plus support for these wiki content formats and
+the static content generator:
 
     sudo gem install gollum -v 2.5.2
     sudo gem install redcarpet org-ruby wikicloth
+    sudo gem install thin
 
 gollum version 2.5.2 is used as newer versions of gollum produce different
 HTML output from the same markdown file. In some cases, this causes the

--- a/scripts/common.inc
+++ b/scripts/common.inc
@@ -100,60 +100,43 @@ function generate () {
 }
 
 function launch_gollum () {
-    # check for netstat
-    which netstat > /dev/null 2>&1
-    missing_netstat=$?
+    branch=$(git rev-parse --abbrev-ref HEAD)
 
-    if [[ $missing_netstat -eq 1 ]] ; then
-       echo "ERROR: no netstat command found"
-       return
-    fi
+    # start gollum
+    ruby scripts/gollum.rb $branch
 
-    gollum_pid=$(pgrep -f gollum)
+    # how did it work out?
+    exitcode=$?
 
-    if [[ $gollum_pid -eq 0 ]] ; then
-      # get the currently checked-out branch to set --ref
-      branch=`git rev-parse --abbrev-ref HEAD`
+    if [ "$exitcode" = "0" ] ; then
+        echo -n 'Waiting for gollum to start..'
 
-      gollum --ref ${branch} --live-preview ${PWD} > /dev/null 2>&1 &
+        no_pid_file_ready=1
 
-      echo -n "Launching gollum"
+        while (( $no_pid_file_ready )); do
+            echo -n "."
+            sleep 0.5
 
-      not_running=1
-      while (( $not_running )); do
-          echo -n "."
-          sleep 0.5
-          netstat -na 2>&1 | grep -q ":4567 "
-          not_running=$?
-      done
+            if [ -f /tmp/xwalk-website-gollum.pid ] ; then
+              echo ''
+              gollum_pid=$(cat /tmp/xwalk-website-gollum.pid)
+              no_pid_file_ready=0
+            fi
+        done
 
-      gollum_pid=$(ps -o pid= -C gollum)
-
-      echo
-      echo "Launched gollum with pid $gollum_pid"
+        echo "Launched gollum with pid $gollum_pid"
     else
-      echo "could not launch gollum as it is already running"
+        echo "Could not launch gollum as it is already running"
     fi
-
-    echo "Live preview at http://localhost:4567/fileview"
 }
 
 function kill_gollum () {
-    gollum_pid=$(pgrep -f gollum)
-    if [[ ! $gollum_pid -eq 0 ]] ; then
-      echo -n "killing gollum process $gollum_pid"
-      kill -9 ${gollum_pid}
-
-      while [[ ! $gollum_pid -eq 0 ]] ; do
-          echo -n "."
-          sleep 0.5
-          gollum_pid=$(ps -o pid= -C gollum)
-      done
-
-      echo
-      echo "gollum killed"
+    if [ -f /tmp/xwalk-website-gollum.pid ] ; then
+        gollum_pid=$(cat /tmp/xwalk-website-gollum.pid)
+        kill -9 $gollum_pid
+        rm /tmp/xwalk-website-gollum.pid
     else
-      echo "gollum is not running"
+        echo "Could not kill gollum as it is not running"
     fi
 }
 

--- a/scripts/gollum.rb
+++ b/scripts/gollum.rb
@@ -1,0 +1,61 @@
+# this Ruby program mimics this command line in code:
+# gollum --ref ${branch} --live-preview ${PWD} > /dev/null 2>&1 &
+# the reason being to give better control over the startup sequence
+# for gollum, rather than relying on polling the process list in bash
+
+# code based on
+# http://stackoverflow.com/questions/15617347/fork-webrick-and-wait-for-start
+# to ensure the server is actually started before we write its
+# pid to the file /tmp/xwalk-website-gollum.pid
+
+require 'rubygems'
+require 'tmpdir'
+
+# check whether gollum pid file exists and exit if it does
+pid_file = File.join(Dir.tmpdir, 'xwalk-website-gollum.pid')
+
+if File.exists?(pid_file)
+  raise 'ERROR: pid_file ' + pid_file + ' already exists'
+  Process.exit(1)
+end
+
+# clear the log file
+log_file = File.join(Dir.tmpdir, 'xwalk-website-gollum.log')
+
+if File.exists?(log_file)
+  File.truncate(log_file, 0)
+end
+
+require 'rack'
+require 'thin'
+require 'gollum'
+require 'gollum/app'
+
+gollum_path = '.'
+
+ref = ARGV.first || 'master'
+
+wiki_options = {
+  :live_preview  => true,
+  :allow_uploads => false,
+  :ref => ref
+}
+
+server_options = {
+  :Port => 4567,
+  :Bind => '0.0.0.0'
+}
+
+Precious::App.set(:gollum_path, gollum_path)
+Precious::App.set(:wiki_options, wiki_options)
+
+server = Thin::Server.new(server_options[:Bind], server_options[:Port]) do
+  run Precious::App
+end
+
+server.pid_file = pid_file
+server.log_file = log_file
+
+server.daemonize()
+
+server.start()


### PR DESCRIPTION
This makes it easier to tell when gollum is or isn't available
(I can properly track the pid using a file), reduces the gollum
start up time (by a factor of 10), and slightly improves the time
taken for translating mark-up to HTML (mainly because the HTTP
requests return slightly faster).
