### PR TITLE
More fixes for Crosswalk 8 manifest

### DIFF
--- a/documentation/05-Manifest.php
+++ b/documentation/05-Manifest.php
@@ -663,9 +663,6 @@
     <div data-crosswalk-versions="6-7" data-crosswalk-platforms="webview">
       <pre>
 {
-  "name": "app name",
-  "description": "a sample description",
-  "version": "1.0.0",
   "app": {
     "launch": {
       "local_path": "index.html"
@@ -682,9 +679,6 @@
     <div data-crosswalk-versions="8+" data-crosswalk-platforms="webview">
       <pre>
 {
-  "name": "app name",
-  "xwalk_description": "a sample description",
-  "xwalk_version": "1.0.0",
   "start_url": "index.html",
   "csp": "script-src 'self'; object-src 'self'",
   "xwalk_hosts": [

--- a/manifest-fields.json
+++ b/manifest-fields.json
@@ -57,10 +57,6 @@
     "android": {
       "versions": "2+",
       "deprecated": "8"
-    },
-    "webview": {
-      "versions": "6+",
-      "deprecated": "8"
     }
   },
   "display": {
@@ -101,9 +97,6 @@
     },
     "android": {
       "versions": "8+"
-    },
-    "webview": {
-      "versions": "8+"
     }
   },
   "name.extension": {
@@ -113,9 +106,6 @@
     },
     "android": {
       "versions": "2-7"
-    },
-    "webview": {
-      "versions": "6-7"
     }
   },
   "orientation": {
@@ -151,18 +141,11 @@
     "android": {
       "versions": "2+",
       "deprecated": "8+"
-    },
-    "webview": {
-      "versions": "6+",
-      "deprecated": "8+"
     }
   },
   "xwalk_description.extension": {
     "name": "xwalk_description (extension)",
     "android": {
-      "versions": "8+"
-    },
-    "webview": {
       "versions": "8+"
     }
   },
@@ -190,9 +173,6 @@
   "xwalk_version.extension": {
     "name": "xwalk_version (extension)",
     "android": {
-      "versions": "8+"
-    },
-    "webview": {
       "versions": "8+"
     }
   }


### PR DESCRIPTION
- Add prefixes for version and description (fixes https://crosswalk-project.org/jira/browse/XWALK-2405)
- Remove irrelevant manifest fields for webview
