### PR TITLE
Link individual sample pages to the main samples page

### DIFF
--- a/documentation/Samples/Hello-world.md
+++ b/documentation/Samples/Hello-world.md
@@ -5,7 +5,7 @@
 The smallest of applications -- Hello, World! This sample provides a manifest.json and a minimal set of HTML files to start an application from the ground up.
 
 This application is part of the
-[Crosswalk samples download](https://github.com/crosswalk-project/crosswalk-samples/archive/0.2.tar.gz).
+[Crosswalk samples download](#documentation/samples).
 
 The steps for setting up an environment for Crosswalk are explained
 in detail in the [Getting started](#documentation/getting_started)

--- a/documentation/Samples/SIMD.md
+++ b/documentation/Samples/SIMD.md
@@ -15,7 +15,7 @@ that version or later to be able to run this demo; and you will need
 a device with an Intel x86 chipset (emulated or physical).**
 
 This application is part of the
-[Crosswalk samples download](https://github.com/crosswalk-project/crosswalk-samples/archive/0.2.tar.gz).
+[Crosswalk samples download](#documentation/samples).
 
 The steps for setting up an environment for Crosswalk are explained
 in detail in the [Getting started](#documentation/getting_started)

--- a/documentation/Samples/Tizen.md
+++ b/documentation/Samples/Tizen.md
@@ -7,7 +7,7 @@ some of the Tizen APIs. This sample demonstrates usage of the
 `tizen.systeminfo` API.
 
 This application is part of the
-[Crosswalk samples download](https://github.com/crosswalk-project/crosswalk-samples/archive/0.2.tar.gz).
+[Crosswalk samples download](#documentation/samples).
 
 To use this example, you need to run the application on a Tizen device
 or in the Tizen emulator. Instructions for preparing both are in

--- a/documentation/Samples/WebGL.md
+++ b/documentation/Samples/WebGL.md
@@ -5,7 +5,7 @@
 Ah, the power of WebGL. This sample provides a quick example of integrating ThreeJS into a Crosswalk application.
 
 This application is part of the
-[Crosswalk samples download](https://github.com/crosswalk-project/crosswalk-samples/archive/0.2.tar.gz).
+[Crosswalk samples download](#documentation/samples).
 
 The steps for setting up an environment for Crosswalk are explained
 in detail in the [Getting started](#documentation/getting_started)


### PR DESCRIPTION
Rather than linking to the download tarball from the sample
pages, link to the main page which explains how to get the
download and unpack it.

Fixes https://crosswalk-project.org/jira/browse/XWALK-2481
