### PR TITLE
Add samples of package tools for beta version Crosswalk Android

### DIFF
--- a/documentation/01-Getting_Started.md
+++ b/documentation/01-Getting_Started.md
@@ -18,7 +18,7 @@ For Tizen, a [canary](#documentation/downloads/Release-channels) version is used
     * [Tizen target](#documentation/getting_started/tizen_target_setup)
 3.  [Build a very simple HTML5 application](#documentation/getting_started/build_an_application).
 4.  Run that application using stable releases of Crosswalk:
-    *   [Run on Crosswalk Android, version ${XWALK-STABLE-ANDROID-X86}](#documentation/getting_started/run_on_android)
+    *   [Run on Crosswalk Android, stable version ${XWALK-STABLE-ANDROID-X86} and beta vesion ${XWALK-BETA-ANDROID-X86}](#documentation/getting_started/run_on_android)
     *   [Run on Crosswalk Tizen for x86, canary version](#documentation/getting_started/run_on_tizen)
 5.  For Android only:
     *   [Deploy the application to an Android app store](#documentation/getting_started/deploy_to_android_store)

--- a/documentation/Getting_Started/30-Run_on_Android.md
+++ b/documentation/Getting_Started/30-Run_on_Android.md
@@ -68,3 +68,40 @@ To deploy a shared mode application, you will need to install architecture-speci
 
 *   [ARM](https://download.01.org/crosswalk/releases/crosswalk/android/stable/${XWALK-STABLE-ANDROID-ARM}/arm/crosswalk-apks-${XWALK-STABLE-ANDROID-ARM}-arm.zip)
 *   [Intel (x86)](https://download.01.org/crosswalk/releases/crosswalk/android/stable/${XWALK-STABLE-ANDROID-X86}/x86/crosswalk-apks-${XWALK-STABLE-ANDROID-X86}-x86.zip)
+
+## Package command for beta version
+
+The follows are samples of main packaging commands for Crosswalk beta ${XWALK-BETA-ANDROID-X86}:
+*  Basic packaging command
+
+        > python make_apk.py --package=org.crosswalkproject.example \
+            --manifest=xwalk-simple/manifest.json
+
+*  Package for apecific target architecture, taking x86 as example
+
+        > python make_apk.py --package=org.crosswalkproject.example \
+            --manifest=xwalk-simple/manifest.json --arch=x86
+
+Note that if unspecified, APKs for all possible architestures will be generated.
+
+*  Package an APK enabling remote debugging
+
+        > python make_apk.py --package=org.crosswalkproject.example \
+            --manifest=xwalk-simple/manifest.json --enable-remote-debugging
+
+*  Set orientation of display
+
+        > python make_apk.py --package=org.crosswalkproject.example \
+            --manifest=xwalk-simple/manifest.json --orientation=landscape
+
+*  Get help message
+
+        > python make_apk.py -h
+
+Since new features for the package tools are added continuely, this command is helpful when try newest version.
+
+*  Print debug message
+
+        > python make_apk.py --verbose
+
+When you meet problem with the package tools, using this argument can output more information to help developers to debug.


### PR DESCRIPTION

As users and QA demanding, we should provide the samples of packaging commands
for beta version of Crosswalk Android since the new features is added continuely.