### PR TITLE
Add RSS feed for the blog

### DIFF
--- a/public/_data.json
+++ b/public/_data.json
@@ -1,5 +1,8 @@
 {
   "sitemap": {
     "layout": false
+  },
+  "feed": {
+    "layout": false
   }
 }

--- a/public/_layout.ejs
+++ b/public/_layout.ejs
@@ -107,6 +107,7 @@
                 </li>
                 <% break %>
             <% } %>
+            <li><h5><a href="http://crosswalk-project.org/feed.xml">RSS Feed</a></h5></li>
           </ul>
           </div>
           <div class="footer-block grid-1-of-3">

--- a/public/feed.xml.ejs
+++ b/public/feed.xml.ejs
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title><%- title %></title>
+    <link><%- url %></link>
+    <description><%- description %></description>
+    <atom:link href="<%- url %>/feed.xml" rel="self" type="application/rss+xml" />
+    <% for(slug in public.blog._data) { %>
+    <% var post = public.blog._data[slug] %>
+    <% var link = ("url" in post ? post.url : url + "/blog/" + slug + ".html") %>
+      <item>
+        <title><%- post.title %></title>
+        <description><![CDATA[<%- partial("blog/" + slug) %>]]></description>
+        <pubDate><%- Date(post.date) %></pubDate>
+        <link><%- link %></link>
+        <guid isPermaLink="true"><%- link %></guid>
+      </item>
+    <% } %>
+  </channel>
+</rss>


### PR DESCRIPTION
Add an RSS feed for the blog entries.
- A new feed.xml.ejs is created, which parses the blog entries and populates the XML feed. The URL is either local to the website, or remote depending on the type of blog entry. The template is based on the recipe at http://harpjs.com/recipes/blog-rss-feed
- the feed is added to the top level _data.json to specify that no layout needs to be applied
- the feed is added to the footer, under the recent blog entries, _layout.ejs 

Note: the feed link is crosswalk-project/feed.xml. It would have been better to add it under blog/, but I got some errors when adding the feed item to blog/_data.json

Tested with "harp server" and an RSS feed reader

BUG=XWALK-2866
