### PR TITLE
Add link to the FAQ in the navbar

### DIFF
--- a/public/_includes/nav.ejs
+++ b/public/_includes/nav.ejs
@@ -20,6 +20,9 @@
       <a href="https://github.com/crosswalk-project/crosswalk-website/wiki" class="nav-link">Wiki</a>
     </li>
     <li class="nav-item">
+      <a href="/documentation/about/faq.html" class="nav-link">FAQ</a>
+    </li>
+    <li class="nav-item">
       <a href="/documentation" class="nav-link button button--tertiary" id="getting-started-nav">Get&nbsp;Started</a>
     </li>
   </ul>


### PR DESCRIPTION
Adds a top-level link to the FAQ in the navigation bar. The FAQ is something users may want to check when they first visit the site, so it's good to highlight it.

I tested this on desktop at various window sizes, and it didn't seem to break the navigation.
