### PR TITLE
Adding deploy.php to the public directory for compiles.

### DIFF
--- a/public/deploy.php.ejs
+++ b/public/deploy.php.ejs
@@ -1,0 +1,120 @@
+<?php
+	/*
+	 * Copyright © 2012 by Eric Schultz.
+	 *
+	 * Issued under the MIT License
+	 *
+	 * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), 
+	 * to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+	 * and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+	 *
+	 * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+	 *
+	 * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+	 * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+	 * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+	 */
+	 
+	set_time_limit(90);
+
+	include '../util/local-config.php';
+
+	// Make sure the configuration is setup
+	if (!isset($arrConfig) || empty($arrConfig)) {
+		error_log("GitHub Webhook Error: missing local-config.php or no configuration definitions setup");
+		exit;
+	}
+
+	// Check for the GitHub WebHook Payload
+	if (!isset($_POST['payload'])) {
+		error_log("GitHub Webhook Error: missing expected POST parameter 'payload'");
+		exit;
+	}
+  
+  // Check for the HTTP_X_HUB_SIGNATURE
+  if(!isset($_SERVER['HTTP_X_HUB_SIGNATURE'])) {
+  	http_response_code(401);
+  	error_log("GitHub Webhook Error: Secret (X-Hub-Signature header) is missing from request. Have you set a secret in GitHub's project settings?");
+  }
+
+	// Grab the tastylious JSON payload from GitHub
+	$objPayload = json_decode(stripslashes($_POST['payload']));
+
+  // Get the request body
+  $payloadBody = false;
+  switch($_SERVER['CONTENT_TYPE']) {
+  	case 'application/json':
+  		echo "Received JSON data in body.\n";
+  		$payloadBody = file_get_contents('php://input');
+  		break;
+  	case 'application/x-www-form-urlencoded':
+  		echo "Received URL-encoded form data in body.\n";
+  		$payloadBody = file_get_contents('php://input');
+  		break;
+  	default:
+  		http_response_code(400);
+  		error_log("GitHub Webhook Error: Don't know what to do with {$_SERVER['CONTENT_TYPE']} content type.");
+  } 
+  if(!$payloadBody) {
+  	http_response_code(400);
+  	error_log('GitHub Webhook Error: No POST body sent.');
+  }
+  
+	// Loop through the configs to see which one matches the payload
+	foreach ($arrConfig as $strSiteName => $arrSiteConfig) {
+		
+		// Merge in site config defaults
+		$arrSiteConfig = array_merge(
+			array(
+				'repository' => '*',
+        'secretkey' => '*',
+				'branch' => '*',
+        'server' => '*',
+				'execute' => array()
+			), 
+			$arrSiteConfig
+		);
+    
+    // Hashed secret key
+    $secretKey = "sha1=" . hash_hmac('sha1', $payloadBody, $arrSiteConfig['secretkey'], false);
+    
+    // Secret key check
+    if(($arrSiteConfig['secretkey'] != '*') && md5($secretKey) !== md5($_SERVER['HTTP_X_HUB_SIGNATURE'])) {
+      error_log("GitHub Webhook Error: Secret (X-Hub-Signature header) is wrong or does not match request body.");
+      exit();
+    }
+
+		// Repository name check
+		if (($arrSiteConfig['repository'] != '*') && ($arrSiteConfig['repository'] != $objPayload->repository->name)) {
+      error_log("GitHub Webhook Error: Repository sent does not match local-config.");
+      exit();
+		}
+		   
+		// Release and production check
+		if (($arrSiteConfig['server'] == 'production') && (isset($objPayload->release)) && ($objPayload->release->draft != 'true') && ($objPayload->release->prerelease != 'true')) {
+			$arrSiteConfig['execute'] = (array)$arrSiteConfig['execute'];
+
+			foreach ($arrSiteConfig['execute'] as $arrCommand) {
+				$arrOutput = array();
+				exec($arrCommand, $arrOutput);
+
+				if (isset($boolDebugLogging) && $boolDebugLogging) {
+					error_log("GitHub Webhook Update (" . $strSiteName . "):\n" . implode("\n", $arrOutput));
+				}
+			}
+    }
+  
+		// Push and non-production check
+		elseif (($arrSiteConfig['server'] != 'production') && (isset($objPayload->ref)) && ($arrSiteConfig['branch'] != '*') && ('refs/heads/'.$arrSiteConfig['branch'] == $objPayload->ref)) {
+			$arrSiteConfig['execute'] = (array)$arrSiteConfig['execute'];
+
+			foreach ($arrSiteConfig['execute'] as $arrCommand) {
+				$arrOutput = array();
+				exec($arrCommand, $arrOutput);
+
+				if (isset($boolDebugLogging) && $boolDebugLogging) {
+					error_log("GitHub Webhook Update (" . $strSiteName . "):\n" . implode("\n", $arrOutput));
+				}
+			}
+		}
+	}


### PR DESCRIPTION
When harp compiles the www directory, it removed everything and
regenerates everything again. In order to have the deploy.php file in
the compiled version, deploy.php.ejs was added to the /public directory.
