### PR TITLE
[Android] Mark down proguard Crosswalk

### DIFF
--- a/public/documentation/about/faq.md
+++ b/public/documentation/about/faq.md
@@ -93,6 +93,18 @@ Also note that we don't have a way to package your app with Crosswalk for deploy
 
 Crosswalk does not support iOS at this time.
 
+### <a id="How-to-proguard-Crosswalk"></a>How to proguard Crosswalk?
+
+Don't proguard xwalk library because of broken JNI link. Add following ProGuard rules in proguard-project.txt file.
+
+    -keep class org.xwalk.core.** {
+        *;
+    }
+    -keep class org.chromium.** {
+	    *;
+    }
+    -keepattributes **
+
 ## <a id="Canvas-and-WebGL-support"></a>Canvas and WebGL support
 
 ### <a id="Why-wont-WebGL-work-in-Crosswalk-on-my-device"></a>Why won't WebGL work in Crosswalk on my device?

--- a/public/documentation/embedding_crosswalk/crosswalk_aar.md
+++ b/public/documentation/embedding_crosswalk/crosswalk_aar.md
@@ -94,7 +94,7 @@ The AAR remote Maven repository is https://download.01.org/crosswalk/releases/cr
 
 Then install it into the local Maven repository:
     
-    $ mvn install:install-file -DgroupId=org.xwalk -DartifactId=xwalk_core_library \
+    $ mvn install:install-file -DgroupId=org.xwalk -DartifactId=xwalk_core_library_canary \
           -Dversion=9.38.207.0 -Dpackaging=aar  -Dfile=crosswalk-9.38.207.0.aar \
           -DgeneratePom=true
 
@@ -113,6 +113,8 @@ Then install it into the local Maven repository:
         }
     }
     ```
+
+    Using mavenLocal() instead of remote repo url to refer local aar.
 
 3. The dependency (a reference) to the AAR library will look like (9.38.208.8 is a crosswalk version):
     
@@ -266,9 +268,9 @@ The Maven android plugin has a known issue that it can't build multiple APKs for
 5.  Build your project with Maven, the following commands will build the corresponding arch apk in target/ directory:
 
         $ mvn clean install -Px86
-        $ adb ./target/install xwalk-aar-example-1.0.0-SNAPSHOT-x86.apk
+        $ adb install ./target/xwalk-aar-example-1.0.0-SNAPSHOT-x86.apk
         $ mvn clean install -Parm
-        $ adb ./target/install xwalk-aar-example-1.0.0-SNAPSHOT-arm.apk
+        $ adb install ./target/xwalk-aar-example-1.0.0-SNAPSHOT-arm.apk
 
 ## Samples
 


### PR DESCRIPTION
Don't proguard xwalk library because of broken JNI link. Add specific keep options in proguard-project.txt file.

BUG=XWALK-2878