### PR TITLE
Delete the deprecated instruction to install Oracle JDK

### DIFF
--- a/public/contribute/building_crosswalk.md
+++ b/public/contribute/building_crosswalk.md
@@ -169,10 +169,6 @@ Chrome's process, so make sure you are
     xorg-x11-utils zlib-devel.i686 zlib.i686
     ```
 
-2.  Install the Oracle JDK. It is
-    available from the
-    [Oracle Java download site](http://www.oracle.com/technetwork/java/javase/downloads/java-archive-downloads-javase6-419409.html).
-
 2.  Configure gyp.
 
     gyp is the build system generator used in Chromium to generate actual build


### PR DESCRIPTION
  Open JDK is currently used, and it is already installed
  in the previous instruction:
  sudo ./build/install-build-deps-android.sh