### PR TITLE
[Android] Use API level 21 for the latest xwalk_core_library

### DIFF
--- a/public/documentation/cordova/migrate_an_application.md
+++ b/public/documentation/cordova/migrate_an_application.md
@@ -21,7 +21,7 @@ Once you have the pre-requisites, you can install the Cordova command line tools
 
     $ npm install -g cordova@3.5
 
-(You're installing Cordova 3.5.*, as this is the version supported by the current stable Crosswalk.)
+(Please install Cordova 3.5.* if you're using Crosswalk-8 and Crosswalk-9, install Cordova 3.6 for Crosswalk-10)
 
 This installs the tools globally so they are available from any shell.
 
@@ -157,6 +157,8 @@ Once you have the application working with standard Cordova, you can move on to 
         $ cordova build android
 
     The `android update` command used above takes a `--target` option, specifying which Android API level you want to target. If you only have one platform version installed in your Android SDK, this option is not required; but if you have multiple platform versions installed, you need to specify which one to use.
+
+    The latest xwalk_core_library need target Android 5.0.1 (API level 21), so you need run the command with the `--target` option of `"android-21"` in `platforms/android` directory.
 
     To get a list of the targets available in your Android SDK, run this command:
 


### PR DESCRIPTION
Update the documentation of Using target Android API level.