### PR TITLE
Remove Tizen download links and add link to Crosswalk 11 release notes

### DIFF
--- a/public/documentation/downloads.ejs
+++ b/public/documentation/downloads.ejs
@@ -91,24 +91,6 @@
     </td>
     </tr>
 
-    <tr>
-    <th>Tizen 3.0 Mobile<br/>(x86)</th>
-    <td>-</td>
-    <td>-</td>
-    <td>
-    <a href="https://download.01.org/crosswalk/releases/crosswalk/tizen-mobile/canary/9.37.196.0/crosswalk-9.37.196.0-0.i686.rpm" data-channel="canary" data-os="tizen-mobile" data-arch="x86">9.37.196.0</a>
-    </td>
-    </tr>
-
-    <tr>
-    <th>Tizen 3.0 IVI<br/>(x86)</th>
-    <td>-</td>
-    <td>-</td>
-    <td>
-    <a data-role="static-download-link" data-channel="canary" data-os="tizen-ivi" data-arch="x86"></a>
-    </td>
-    </tr>
-
     </table>
 
     <p><a href="https://download.01.org/crosswalk/releases/crosswalk/">More downloads…</a></p>
@@ -116,6 +98,7 @@
     <h2>Release notes</h2>
 
     <ul>
+    <li><a href="/blog/crosswalk-11-beta.html">Crosswalk-11</a></li>
     <li><a href="/blog/crosswalk-10-beta.html">Crosswalk-10</a></li>
     <li><a href="https://github.com/crosswalk-project/crosswalk-website/wiki/Crosswalk-9-release-notes">Crosswalk-9</a></li>
     <li><a href="https://github.com/crosswalk-project/crosswalk-website/wiki/Crosswalk-8-release-notes">Crosswalk-8</a></li>


### PR DESCRIPTION
The Tizen download links (especially mobile which is obsolete) are not relevant for the average Crosswalk user,   let's remove them to avoid confusion.