### PR TITLE
Fix Cordova migration instructions to use correct folder when running android update

### DIFF
--- a/public/documentation/cordova/migrate_an_application.md
+++ b/public/documentation/cordova/migrate_an_application.md
@@ -141,7 +141,7 @@ Once you have the application working with standard Cordova, you can move on to 
         # path; this variable is required for the manual builds below
         $ export ANDROID_HOME=$(dirname $(dirname $(which android)))
 
-        $ cd platforms/android/CordovaLib/
+        $ cd platforms/android/
 
         # this updates the CordovaLib project and the
         # xwalk_core_library subproject and target Android 4.4.2 (API


### PR DESCRIPTION
The instructions to migrate an existing Cordova app to Crosswalk tell to run this command from folder platforms/android/CordovaLib/:

android update project --subprojects --path .   --target "android-19"

However when trying to migrate a project to Crosswalk 11 (using target "android-21") with these instrucions I encountered bug https://crosswalk-project.org/jira/browse/XWALK-3234. The bug went away when I ran android update from the platforms/android folder.

So this PR updates the instructions to always issue android update from platforms/android. I'm not sure if this is only needed for API 21 targets, I assume not but it would be good if someone could confirm.

BUG=XWALK-3649