### PR TITLE
Correct JAVA_HOME value

### DIFF
--- a/public/documentation/getting_started/windows_host_setup.md
+++ b/public/documentation/getting_started/windows_host_setup.md
@@ -77,7 +77,7 @@ To ensure that Ant is using the correct version of Java (the one you just instal
 
 2.  Set *Variable name* to **JAVA_HOME**.
 
-3.  Set *Variable value* to **c:\jdk\bin**.
+3.  Set *Variable value* to **c:\jdk**.
 
 4.  Click *OK*.
 


### PR DESCRIPTION
If it's set to `c:\jdk\bin`, I get
```
Unable to locate tools.jar. Expected to find it in C:\Program Files\Java\jre1.8.
0_40\lib\tools.jar
```
when I start `ant`.

With `c:\jdk` it works fine.