### PR TITLE
FAQ: Remove <a> tags from the page title.

### DIFF
--- a/public/documentation/about/faq.md
+++ b/public/documentation/about/faq.md
@@ -1,4 +1,4 @@
-# <a id="Frequently-asked-questions"></a>Frequently-asked questions
+# Frequently-asked questions
 
 If you have any questions that are not answered below, the crosswalk-help mailing list is a good place to ask them. Alternatively, contact us directly via the #crosswalk IRC channel on Freenode. See the [Community page](/documentation/community.html) for more details.
 


### PR DESCRIPTION
There is no link pointing to that anchor, and the HTML tags end up being
added to the page title in the generated contents.