### PR TITLE
[Android] Update compileSdkVersion for latest AAR

### DIFF
--- a/public/documentation/embedding_crosswalk/crosswalk_aar.md
+++ b/public/documentation/embedding_crosswalk/crosswalk_aar.md
@@ -129,6 +129,8 @@ Then install it into the local Maven repository:
     }
     ```
 
+   The latest AAR need set compileSdkVersion to 21 in build.gradle file.
+
    Gradle places the AAR library in its project directory:
 
     ~/.gradle/caches/modules-2/files-2.1/


### PR DESCRIPTION
Set compileSdkVersion to 21 for the latest AAR.

BUG=XWALK-3813