### PR TITLE
Link Crosswalk samples to latest GitHub version

### DIFF
--- a/public/documentation/samples.md
+++ b/public/documentation/samples.md
@@ -2,13 +2,13 @@
 
 These sample applications can help get you up and running with the Crosswalk Project. 
 
-All sample source is available on github (MIT license).  To use the samples, download the <a href="https://github.com/crosswalk-project/crosswalk-samples/archive/0.8.tar.gz">sample archive</a> and unpack it:
+All sample source is available on [github](https://github.com/crosswalk-project/crosswalk-samples) (MIT license). To use the samples, clone this project:
 
 ```sh
-$ tar xvf crosswalk-samples-0.8.tar.gz
+$ git clone https://github.com/crosswalk-project/crosswalk-samples.git
 ```
 
-This will create a `crosswalk-samples-0.8` directory with several project sub-directories:
+There will be a `crosswalk-samples` directory with several project sub-directories:
 
 *   `extensions-android` &ndash; A simple Crosswalk Android extension example. The [Android extensions tutorial](/documentation/android_extensions.html) explains how this was developed. See [this README](https://github.com/crosswalk-project/crosswalk-samples/blob/master/extensions-android/README.md) for build instructions.
 

--- a/public/documentation/samples/hello-world.md
+++ b/public/documentation/samples/hello-world.md
@@ -5,7 +5,7 @@
 The smallest of applications -- Hello, World! This sample provides a manifest.json and a minimal set of HTML files to start an application from the ground up.
 
 This application is part of the
-[Crosswalk samples download](https://github.com/crosswalk-project/crosswalk-samples/archive/0.2.tar.gz).
+[Crosswalk samples](https://github.com/crosswalk-project/crosswalk-samples).
 
 The steps for setting up an environment for Crosswalk are explained
 in detail in the [Getting started](/documentation/getting_started.html)

--- a/public/documentation/samples/simd.md
+++ b/public/documentation/samples/simd.md
@@ -15,7 +15,7 @@ that version or later to be able to run this demo; and you will need
 a device with an Intel x86 chipset (emulated or physical).**
 
 This application is part of the
-[Crosswalk samples download](https://github.com/crosswalk-project/crosswalk-samples/archive/0.2.tar.gz).
+[Crosswalk samples](https://github.com/crosswalk-project/crosswalk-samples).
 
 The steps for setting up an environment for Crosswalk are explained
 in detail in the [Getting started](/documentation/getting_started.html)

--- a/public/documentation/samples/tizen.md
+++ b/public/documentation/samples/tizen.md
@@ -7,7 +7,7 @@ some of the Tizen APIs. This sample demonstrates usage of the
 `tizen.systeminfo` API.
 
 This application is part of the
-[Crosswalk samples download](https://github.com/crosswalk-project/crosswalk-samples/archive/0.2.tar.gz).
+[Crosswalk samples](https://github.com/crosswalk-project/crosswalk-samples).
 
 To use this example, you need to run the application on a Tizen device
 or in the Tizen emulator. Instructions for preparing both are in

--- a/public/documentation/samples/webgl.md
+++ b/public/documentation/samples/webgl.md
@@ -5,7 +5,7 @@
 Ah, the power of WebGL. This sample provides a quick example of integrating ThreeJS into a Crosswalk application.
 
 This application is part of the
-[Crosswalk samples download](https://github.com/crosswalk-project/crosswalk-samples/archive/0.2.tar.gz).
+[Crosswalk samples](https://github.com/crosswalk-project/crosswalk-samples).
 
 The steps for setting up an environment for Crosswalk are explained
 in detail in the [Getting started](/documentation/getting_started.html)


### PR DESCRIPTION
The samples archives are out-of-date and shall be removed from
https://github.com/crosswalk-project/crosswalk-samples/release

BUG=https://crosswalk-project.org/jira/browse/XWALK-4462