### PR TITLE
Add "test suite" and "contributing test" documentation

### DIFF
--- a/public/contribute/_data.json
+++ b/public/contribute/_data.json
@@ -8,6 +8,9 @@
   "contributing-code": {
     "title": "Contributing code"
   },
+  "contributing_tests": {
+    "title": "Contributing tests"
+  },
   "coding_style": {
     "title": "Coding style"
   },

--- a/public/contribute/_overview.md
+++ b/public/contribute/_overview.md
@@ -20,8 +20,6 @@ Be sure to follow the [contribution guidelines](/contribute/contributing-code.ht
 
 ## Testing
 
-For a quick overview of the overall test results for Crosswalk binaries, see [Crosswalk quality dashboard](/documentation/quality_dashboard.html).
-
 Full details of everything related to test scope, test execution plan, and running tests can be found on the [Crosswalk testing home](https://github.com/crosswalk-project/crosswalk-website/wiki/crosswalk-testing-home).
 
 You are welcome to contribute test cases for Crosswalk Project, the detailed process can be found in [contribute tests](/contribute/contributing_tests.html) page.

--- a/public/contribute/_overview.md
+++ b/public/contribute/_overview.md
@@ -20,12 +20,11 @@ Be sure to follow the [contribution guidelines](/contribute/contributing-code.ht
 
 ## Testing
 
-For a quick overview of the overall test results for Crosswalk
-binaries, see
-[Crosswalk test result indicators](https://crosswalk-project.org/#wiki/Crosswalk-test-result-indicators).
+For a quick overview of the overall test results for Crosswalk binaries, see [Crosswalk quality dashboard](/documentation/quality_dashboard.html).
 
-Full details of everything related to test scope, test execution plan, and running tests
-can be found on the [Crosswalk Testing Home](https://github.com/crosswalk-project/crosswalk-website/wiki/crosswalk-testing-home).
+Full details of everything related to test scope, test execution plan, and running tests can be found on the [Crosswalk testing home](https://github.com/crosswalk-project/crosswalk-website/wiki/crosswalk-testing-home).
+
+You are welcome to contribute test cases for Crosswalk Project, the detailed process can be found in [contribute tests](/contribute/contributing_tests.html) page.
 
 ## Questions?
 Jump on IRC and chat with other developers; they hang out on Freenode in the #crosswalk channel. Details in the [Community](/documentation/community.html) page.

--- a/public/contribute/contributing_tests.md
+++ b/public/contribute/contributing_tests.md
@@ -1,0 +1,86 @@
+# Contributing Tests
+This page outlines the process for contributing test cases or test suites to Crosswalk, basically the process follows [contributing code](https://crosswalk-project.org/contribute/contributing-code.html) but with more details as follows.
+
+For information on obtaining the source code, see [Crosswalk Test Suite](https://crosswalk-project.org/documentation/test_suite.html).
+
+
+## Overview
+
+Everyone is welcome and even encouraged to contribute test cases and test suites. 
+
+These are the recommended steps for contributing test cases to Crosswalk Test Suite:
+
+* Fork [Crosswalk Test Suite repository](https://github.com/crosswalk-project/crosswalk-test-suite) (and make sure you're still relatively in sync with it if you forked a while ago).
+* Create a new branch for your changes.
+* Develop your changes.
+* Make sure your changes meet the code style guidelines. The check-style script may be of help.
+* Run the unit tests.
+* Add any new files to your working directory.
+* Prepare your commit message.
+* Submit your patch for review using the Github pull request system.
+* Make any changes recommended by the reviewer.
+* Once reviewed, the patch will be landed for you.
+
+More detail about some of these steps is below:
+
+<pre>
+$ git clone https://github.com/crosswalk-project/crosswalk-test-suite.git
+$ git checkout -b topic
+$ git add file1 file2 ... fileN 
+$ git commit (Follow "Commit message guidelines" section below to add commit messages)
+$ git push origin topic
+</pre>
+
+
+## Choose a bug report
+
+The [Jira issue tracker](https://crosswalk-project.org/jira/) is the central point of communication for contributions to Crosswalk. For test suite bugs and tasks, you can choose the [Crosswalk Test Suite component](https://crosswalk-project.org/jira/browse/XWALK/component/10303), choose an issue to work on, or create a new one if no suitable issue exists. To avoid duplication, be sure to search the database before creating new issues.
+
+You should note the ID of the issue you work on, so you can include it in your test case PR, if you need to declare one (see below). The ID is the **XWALK-N** identifier at the end of the URL for the issue: for example, for https://crosswalk-project.org/jira/browse/XWALK-4782, the ID is **XWALK-4782**.
+
+
+## Code style guidelines
+
+Patches must comply with the code style guidelines. See the [Crosswalk Test Suite coding style](https://github.com/crosswalk-project/crosswalk-test-suite/blob/master/doc/Coding_Style_Guide_CheatSheet.md) for details.
+
+
+## Commit message guidelines
+
+Your commits and/or PRs should reference the ID of the issue you are working on. Please refer to "Commit message guidelines" section in [contributing code](https://crosswalk-project.org/contribute/contributing-code.html) page. 
+
+It's better to follow the commit message template for contributing test cases:
+
+<pre>
+[area prefix] Capitalized, short (50 chars or less) summary
+
+More detailed explanatory text, if necessary.  Wrap it to about 72
+characters or so.  In some contexts, the first line is treated as the
+subject of an email and the rest of the text as the body.  The blank
+line separating the summary from the body is critical (unless you omit
+the body entirely); tools like rebase can get confused if you run the
+two together.
+
+Failure analysis goes here; describe possible reasons for the failed.
+If refer to a bug, please use full URL.
+
+Impacted tests(designed|approved): new 0, update 5, delete 0
+Unit test platform: Crosswalk Project for &lt;Android|IoT|Linux|Windows&gt; &lt;version&gt;
+Unit test result summary: pass 5, fail 0, block 0
+
+BUG=https://crosswalk-project.org/jira/browse/XWALK-4782
+</pre>
+
+
+## Respond to reviewers
+
+[Crosswalk Test Suite repository](https://github.com/crosswalk-project/crosswalk-test-suite) reviewer will approve your patch when the PR is reviewed. A reviewer will either approve your patch by responding with "LGTM" in the pull request, or request revisions to your patch. The review process can consist of multiple iterations between you and the reviewer as you submit revised patches.
+
+
+## License and author name
+
+Except as noted in COPYING and/or NOTICE files, or as headed with license info, Crosswalk Test Suite source code uses a BSD-style license that can be found in the LICENSE file.
+
+Make sure that any new source code you introduce contains the appropriate license text at the beginning of the file. If you are the author of a new file, the preferred license text to include can be found in the LICENSE file or any existing file.
+
+You should also add your name to the AUTHORS file the first time you make a patch. Please see the [Crosswalk test templates](https://github.com/crosswalk-project/crosswalk-test-suite/blob/master/tools/template/).
+ 

--- a/public/contribute/contributing_tests.md
+++ b/public/contribute/contributing_tests.md
@@ -1,7 +1,7 @@
 # Contributing Tests
-This page outlines the process for contributing test cases or test suites to Crosswalk, basically the process follows [contributing code](https://crosswalk-project.org/contribute/contributing-code.html) but with more details as follows.
+This page outlines the process for contributing test cases or test suites to Crosswalk, basically the process follows [contributing code](/contribute/contributing-code.html) but with more details as follows.
 
-For information on obtaining the source code, see [Crosswalk Test Suite](https://crosswalk-project.org/documentation/test_suite.html).
+For information on obtaining the source code, see [Crosswalk Test Suite](/documentation/test_suite.html).
 
 
 ## Overview
@@ -46,7 +46,7 @@ Patches must comply with the code style guidelines. See the [Crosswalk Test Suit
 
 ## Commit message guidelines
 
-Your commits and/or PRs should reference the ID of the issue you are working on. Please refer to "Commit message guidelines" section in [contributing code](https://crosswalk-project.org/contribute/contributing-code.html) page. 
+Your commits and/or PRs should reference the ID of the issue you are working on. Please refer to "Commit message guidelines" section in [contributing code](/contribute/contributing-code.html) page. 
 
 It's better to follow the commit message template for contributing test cases:
 

--- a/public/documentation/_data.json
+++ b/public/documentation/_data.json
@@ -49,5 +49,8 @@
   },
   "report_bugs": {
     "title": "Report bugs"
+  },
+  "test_suite": {
+    "title": "Test Suite"
   }
 }

--- a/public/documentation/test_suite.md
+++ b/public/documentation/test_suite.md
@@ -1,0 +1,30 @@
+# Test Suite
+
+The Crosswalk Project is an HTML application runtime, built on open source foundations. The Test Suite for Crosswalk Project, a collection of test cases that are intended to be used to test Crosswalk Project to show it's specified set of behaviours is also open source.
+
+The souce code can be obtained from [Crosswalk Test Suite repository](https://github.com/crosswalk-project/crosswalk-test-suite).
+
+## Overview
+
+There are several components in Crosswalk Project, for instance, the Web APIs stands for the APIs can be used by web applications running on the Crosswalk Project runtime, and the Embedding API stands for the Java API for embedding the Crosswalk Project in an Android application. The corresponding test suites for these components are well orginazed with following parts:
+
+* Web API tests
+* Embedding API tests
+* Web Runtime and feature tests
+* Crosswalk based Cordova tests
+* Usecases
+
+Tools, documentations and some other tests e.g. stability tests and BAT tests are also included in the test suite. Please refer to [test suite wiki](https://github.com/crosswalk-project/crosswalk-website/wiki/Crosswalk-test-suite) for more details.
+
+## Development guide
+
+Crosswalk Test Suite provides a series of [development guides](https://github.com/crosswalk-project/crosswalk-test-suite/tree/master/doc) for test cases developers and contributors, which covers test suite source layout, coding style, test case naming convention, folder naming convention, test case classification as well as how to add test cases into test suites for nearly all the kinds of components like Web API, Embedding API, Cordova and Web Runtime. You may also need to understand the [test case priority and test coverage](https://github.com/crosswalk-project/crosswalk-website/wiki/Crosswalk-test-suite) before developing the test cases.
+
+## Branches
+
+Crosswalk Test Suite not only covers master branch but also beta branch since usually case bugs are affected on both of them, sometimes we need to add hotfixes on beta branch. Crosswalk Test Suite branch schedule aligns with [branch dates](https://github.com/crosswalk-project/crosswalk-website/wiki/Release-dates) of Crosswalk Project which follows [Crosswalk release methodology](https://github.com/crosswalk-project/crosswalk-website/wiki/Release-methodology).
+
+## Contribute test cases
+
+No test is too small or too simple, everyone is welcome and even encouraged to contribute to test development, please refer to detailed contribution steps in [contribute tests](https://crosswalk-project.org/contribute/contributing-tests.html) page.
+

--- a/public/documentation/test_suite.md
+++ b/public/documentation/test_suite.md
@@ -26,5 +26,5 @@ Crosswalk Test Suite not only covers master branch but also beta branch since us
 
 ## Contribute test cases
 
-No test is too small or too simple, everyone is welcome and even encouraged to contribute to test development, please refer to detailed contribution steps in [contribute tests](https://crosswalk-project.org/contribute/contributing-tests.html) page.
+No test is too small or too simple, everyone is welcome and even encouraged to contribute to test development, please refer to detailed contribution steps in [contribute tests](/contribute/contributing-tests.html) page.
 


### PR DESCRIPTION
To make community users know more about test suite
for Crosswalk Project, add two pages below:

1. Add "test_suite.md" under "documentation" folder
2. Add "contributing_tests.md" under "contribute"
folder
3. Update "##Testing" section in "_overview.md" in
"contribute" folder