### PR TITLE
Explain what the Cordova Android packages are for

### DIFF
--- a/public/documentation/downloads.ejs
+++ b/public/documentation/downloads.ejs
@@ -17,6 +17,8 @@
     <p>For more about the meaning of the version numbers, see the
     <a href="https://github.com/crosswalk-project/crosswalk-website/wiki/release-methodology/version-numbers">Release methodology</a> page.</p>
 
+    <p>Cordova users should refer to the <a href="https://crosswalk-project.org/documentation/cordova/cordova_4.html">Crosswalk Webview</a> Plugin, which will download the Crosswalk library automatically. The Cordova Android archives below contain Crosswalk's fork of the Cordova Android platform 3.6.3</a> and are provided for compatibility with legacy plugins, but in general are not recommended and may be deprecated at any time. If you do need to use Cordova 3, follow <a href="/documentation/cordova/cordova_3.html">these instructions</a>.
+
     <table class="downloads-table">
 
     <tr>


### PR DESCRIPTION
The download section contains links to "Cordova Android" packages for the old Cordova 3 fork, but doesn't talk about the webview plugin at all. Added a paragraph to explain the differences.