### PR TITLE
Refactor version numbers and update to latest ones

### DIFF
--- a/public/js/versions.js
+++ b/public/js/versions.js
@@ -32,56 +32,52 @@
  * website (eg., without needing to run './site.sh mklive').
  *
  */
+
+var stable="14.43.343.23";
+var beta="15.44.384.6";
+var canary="16.44.397.0";
+
 var versions = {
     stable: {
         android: {
-            x86: "14.43.343.17",
-            arm: "14.43.343.17"
+            x86: stable,
+            arm: stable
         },
         'android-webview': {
-            x86: "14.43.343.17",
-            arm: "14.43.343.17"
+            x86: stable,
+            arm: stable
         },
         cordova: {
-            x86: "14.43.343.17",
-            arm: "14.43.343.17"
-        },
-        tizen: {
-            x86: "3.32.53.4"
+            x86: stable,
+            arm: stable
         }
     },
     beta: {
         android: {
-            x86: "14.43.343.17",
-            arm: "14.43.343.17"
+            x86: beta,
+            arm: beta
         },
         'android-webview': {
-            x86: "14.43.343.17",
-            arm: "14.43.343.17"
+            x86: beta,
+            arm: beta
         },
         cordova: {
-            x86: "14.43.343.17",
-            arm: "14.43.343.17"
-        },
-        tizen: {
-            x86: "4.32.76.2"
+            x86: beta,
+            arm: beta
         }
     },
     canary: {
       android: {
-          x86: "15.44.371.0",
-          arm: "15.44.371.0"
+          x86: canary,
+          arm: canary
       },
       'android-webview': {
-          x86: "15.44.371.0",
-          arm: "15.44.371.0"
+          x86: canary,
+          arm: canary
       },
       cordova: {
-          x86: "15.44.371.0",
-          arm: "15.44.371.0"
-      },
-      tizen: {
-          x86: "15.44.371.0"
+          x86: canary,
+          arm: canary
       }
     }
 };


### PR DESCRIPTION
At the moment the Crosswalk download versions are statically stored in public/js/versions.js and are separated by channel, download package and architecture. However the numbers effectively change only across channels. I refactored the version numbers in three variables that are used in the JSON data, this way we only need to update three versions.

Eventually we should do this programmatically or this information will invariably be out of date, but for now this is a quick hack to at least make the manual updates less painful. 