### PR TITLE
Fix typo in instructions to use a local crosswalk build

### DIFF
--- a/public/blog/using-custom-crosswalk-in-cordova-plugin.md
+++ b/public/blog/using-custom-crosswalk-in-cordova-plugin.md
@@ -56,7 +56,7 @@ Next, you'll need to change the gradle configuration of the plugin. From your co
 At the beginning of the file, you'll see the Maven repository configuration:
 
 ```
-Repositories {
+repositories {
     Maven {
         url 'https://download.01.org/crosswalk/releases/crosswalk/android/maven2'
     }
@@ -66,7 +66,7 @@ Repositories {
 To use the local Maven repository instead, replace the text above with the following:
 
 ```
-Repositories {
+repositories {
     mavenLocal()
 }
 ```


### PR DESCRIPTION
Fixes a typo in the blog post https://crosswalk-project.org/blog/using-custom-crosswalk-in-cordova-plugin.html that caused the instructions to fail. 