### PR TITLE
Simplify the Windows documentation using the latest version of crosswalk-app-tools

### DIFF
--- a/public/documentation/windows/build_an_application.md
+++ b/public/documentation/windows/build_an_application.md
@@ -65,4 +65,10 @@ However, because Crosswalk applications are intended to integrate well with the 
 
         See [the manifest documentation](/documentation/manifest.html) for more information.
 
-Once you've done this, you're ready to run the application on a target.
+3. From your command line, run:
+
+   ```
+    > crosswalk-pkg --platforms=windows xwalk-simple
+   ```
+
+   This will download the Crosswalk libraries, package the application defined in the specified manifest.json file and produce an .msi (in our example `com.app.simple-0.1.0.0.msi`). The .msi is currently a 32-bit build of Crosswalk for Windows and should run fine on both 32-bit and 64-bit Windows. Once you've done this, you're ready to run the application on a target.

--- a/public/documentation/windows/run_on_windows.md
+++ b/public/documentation/windows/run_on_windows.md
@@ -1,28 +1,13 @@
 # Run a Crosswalk App on Windows
 
-## Run using Crosswalk packaging tool
+## Run a packaged Crosswalk application
 
-1. Download latest Crosswalk binary from: https://download.01.org/crosswalk/releases/crosswalk/windows/
-
-   (Note that this step will not be required when Crosswalk For Windows binaries are published on download.01.org)
-
-2. In your command line, inside the directory of the application you want to build run:
-
-   ```
-    > crosswalk-pkg \
-        --platforms=windows \
-        --crosswalk=C:\Users\alexisme\Downloads\crosswalk-15.44.374.0.zip \
-        xwalk-simple
-   ```
-
-   This will package the application defined in the specified manifest.json file and produce an .msi (in our example `com.app.simple-0.1.0.0.msi`). The .msi is currently a 32-bit build of Crosswalk for Windows and should run fine on both 32-bit and 64-bit Windows.
-
-3. Click on the .msi and follow the installation instructions.
-4. After the installation successfully finishes you should be able to see your application in the start menu. Click on it and launch the application.
+1. Double-click on the .msi produced following the [build an application](build_an_application) section and follow the installation instructions.
+2. After the installation successfully finishes you should be able to see your application in the start menu. Double-click on it to launch it.
 
    Note : Each .msi of Crosswalk applications contains its own copy of the Crosswalk runtime, it is not shared between installed Crosswalk based applications.
 
-## <a class='doc-anchor' id='Run-using-Crosswalk-binary-directly'></a>Run using Crosswalk binary directly
+## <a class='doc-anchor' id='Run-using-Crosswalk-binary-directly'></a>Run using the Crosswalk binary directly
 
 If you want faster code -> test -> debug cycles you can run Crosswalk for Windows from the command line. This enables you to test your code changes without creating an .msi every time.
 

--- a/public/documentation/windows/windows_host_setup.md
+++ b/public/documentation/windows/windows_host_setup.md
@@ -47,70 +47,16 @@ In the command line (using cmd.exe for example) type :
 > npm install https://github.com/crosswalk-project/crosswalk-app-tools.git
 ```
 
+Note: the version of crosswalk-app-tools currently available in the NPM package repository doesn't yet support windows.
+
 ## <a class="doc-anchor" id="Verify-your-environment"></a>Verify your environment
 Check that you have installed the tools properly by running these commands:
 
 ```
-> crosswalk-app --help
-Crosswalk Project Application Packaging Tool
-
-    crosswalk-app create <package-id>           Create project <package-id>
-                  --platforms=<target>          Optional, e.g. "windows"
-
-    crosswalk-app build [release|debug] [<dir>] Build project to create packages
-                                                Defaults to "debug" when not given
-                                                Tries to build in current dir by default
-
-    crosswalk-app update <channel>|<version>    Update Crosswalk to latest in named
-                                                channel, or specific version
-
-    crosswalk-app platforms                     List available target platforms
-
-    crosswalk-app help                          Display usage information
-
-    crosswalk-app version                       Display version information
-
-Options for platform 'android'
-
-    For command 'create'
-        --android-crosswalk                     Channel name (stable/beta/canary)
-                                                or version number (w.x.y.z)
-Environment variables for platform 'android'
-
-    CROSSWALK_APP_TOOLS_CACHE_DIR               Keep downloaded files in this dir
-```
-
-```
-> candle --version
-Windows Installer XML Toolset Compiler version 3.10.0.2103
-Copyright (c) Outercurve Foundation. All rights reserved.
-
- usage:  candle.exe [-?] [-nologo] [-out outputFile] sourceFile [sourceFile ...] [@responseFile]
-
-   -arch      set architecture defaults for package, components, etc.
-              values: x86, x64, or ia64 (default: x86)
-   -d<name>[=<value>]  define a parameter for the preprocessor
-   -ext <extension>  extension assembly or "class, assembly"
-   -fips      enables FIPS compliant algorithms
-   -I<dir>    add to include search path
-   -nologo    skip printing candle logo information
-   -o[ut]     specify output file (default: write to current directory)
-   -p<file>   preprocess to a file (or stdout if no file supplied)
-   -pedantic  show pedantic messages
-   -platform  (deprecated alias for -arch)
-   -sfdvital  suppress marking files as Vital by default (deprecated)
-   -ss        suppress schema validation of documents (performance boost) (deprecated)
-   -sw[N]     suppress all warnings or a specific message ID
-              (example: -sw1009 -sw1103)
-   -swall     suppress all warnings (deprecated)
-   -trace     show source trace for errors, warnings, and verbose messages (deprecated)
-   -v         verbose output
-   -wx[N]     treat all warnings or a specific message ID as an error
-              (example: -wx1009 -wx1103)
-   -wxall     treat all warnings as errors (deprecated)
-   -? | -help this help information
-
-For more information see: http://wixtoolset.org/
+> crosswalk-app check windows
+  + Checking host setup for target windows
+  + Checking for candle... ...ram Files (x86)\WiX Toolset v3.10\bin\candle.exe
+  + Checking for light... ...ogram Files (x86)\WiX Toolset v3.10\bin\light.exe
 ```
 
 Congratulations, your system is ready for Windows development with Crosswalk.


### PR DESCRIPTION
* Use "crosswalk-app check windows" to verify the setup
* Download the crosswalk zip automatically with app-tools
* Move the packaging instructions from "run an application" to "build an application"