### PR TITLE
Update instructions to use app-tools from NPM

### DIFF
--- a/public/documentation/windows/windows_host_setup.md
+++ b/public/documentation/windows/windows_host_setup.md
@@ -44,10 +44,8 @@ It is the tool which will create installable packages of your Crosswalk applicat
 In the command line (using cmd.exe for example) type :
 
 ```
-> npm install -g https://github.com/crosswalk-project/crosswalk-app-tools.git
+> npm install -g crosswalk-app-tools
 ```
-
-Note: the version of crosswalk-app-tools currently available in the NPM package repository doesn't yet support windows.
 
 ## <a class="doc-anchor" id="Verify-your-environment"></a>Verify your environment
 Check that you have installed the tools properly by running these commands:


### PR DESCRIPTION
Update instructions to reflect the fact that the crosswalk-app-tools version in NPM now supports Windows. 