### PR TITLE
Update proguard samples

### DIFF
--- a/www/documentation/samples/proguard-xwalk.txt
+++ b/www/documentation/samples/proguard-xwalk.txt
@@ -63,7 +63,7 @@
 # Rules for org.chromium classes:
 # Keep annotations used by chromium to keep members referenced by native code
 -keep class org.chromium.base.*Native*
--keep class org.chromium.base.JNINamespace
+-keep class org.chromium.base.annotations.JNINamespace
 -keepclasseswithmembers class org.chromium.** {
     @org.chromium.base.AccessedByNative <fields>;
 }
@@ -82,9 +82,9 @@
     @org.chromium.base.UsedBy* *;
 }
 
--keep @org.chromium.base.JNINamespace* class *
+-keep @org.chromium.base.annotations.JNINamespace* class *
 -keepclassmembers class * {
-    @org.chromium.base.CalledByNative* *;
+    @org.chromium.base.annotations.CalledByNative* *;
 }
 
 # Suppress unnecessary warnings.


### PR DESCRIPTION
The current version of Crosswalk in the documentation page [here](https://crosswalk-project.org/documentation/embedding_crosswalk.html) is Crosswalk 17.

```
$ wget https://download.01.org/crosswalk/releases/crosswalk/android/beta/17.46.448.6/x86/crosswalk-webview-17.46.448.6-x86.zip
```

Crosswalk 17 uses Chromium 46 (see the documentation [here](https://github.com/crosswalk-project/crosswalk-website/wiki/Release-dates)).

As the consequences, the old proguard samples caused my application to crash with this new version (it worked properly with Crosswalk 16, but it didn't work in Crosswalk 17).

After checking [crosswalk repository](https://github.com/crosswalk-project/crosswalk/blob/master/app/android/app_template/proguard-xwalk.txt), we need to update the provided sample.

See: https://github.com/crosswalk-project/crosswalk/commit/addc73750a033fb191338b31b6ae6593613966da#diff-0f4dc3fa316de7b0457ecec0bdc7fdca