### PR TITLE
Building Crosswalk: Remove Tizen instructions.

### DIFF
--- a/public/contribute/building_crosswalk.md
+++ b/public/contribute/building_crosswalk.md
@@ -272,53 +272,6 @@ Chrome's process, so make sure you are
 
     The AAR files will both be located in the `out/Release` directory.
 
-## Building Crosswalk for Tizen
-
-If you are unfamiliar with the RPM packaging process on Tizen, please
-consult the
-[GBS documentation](https://source.tizen.org/documentation/reference/git-build-system).
-
-Crosswalk's layout is a bit unusual, as it actually contains several
-independent git and Subversion repositories in the same directory tree.
-We employ some tricks to make it work with GBS, but it should all be
-transparent to users - the only actual caveat is that GBS will
-build _everything_ that is in your source tree regardless of whether
-it has been committed or not; that is, it always acts as if
-the `--include-all` parameter has been passed to `gbs build`.
-
-That said, building an RPM for Tizen (after properly setting up your
-Tizen repositories) should be a matter of calling `gbs build`:
-
-    cd /path/to/src/xwalk
-    gbs build -A i586
-
-By default, the generated RPM files end up in
-`~/GBS-ROOT/local/repos/<repository name>/i586/RPMS`.
-
-### Testing a Tizen build
-
-The steps for installing a Tizen rpm on a device are covered in
-[Tizen target set up](/documentation/tizen/tizen_target_setup.html).
-
-Running an application on Tizen is covered in
-[Run on Tizen](/documentation/tizen/run_on_tizen.html).
-
-### Incremental builds
-
-By default, each time you call `gbs build`, the Tizen build directory
-will be erased and the build will start from scratch. To avoid that,
-you can set a different build directory in the Tizen chroot,
-outside `/home/abuild/rpmbuild`:
-
-    gbs build -A i586 --define 'BUILDDIR_NAME /tmp/crosswalk-builddir'
-
-### Troubleshooting
-
-* The directory you use as the GBS root must be an actual directory:
-symbolic links can cause problems.
-* The GBS root directory must be on the same partition as your root
-directory (`/`).
-
 ## Running the test suites
 
 If you are interested in running Crosswalk's test suites, you can


### PR DESCRIPTION
Crosswalk for Tizen has not been officially supported for a while now,
so clean up the documentation and remove references to Tizen from it.