### PR TITLE
android: Update the minimum supported Android version.

### DIFF
--- a/public/documentation/android/android_target_setup.md
+++ b/public/documentation/android/android_target_setup.md
@@ -2,7 +2,7 @@
 
 Crosswalk applications will run on either a hardware or emulated Android device.
 
-Any version of Android from 4.0 or higher should work.
+Any version of Android from 4.1 or higher should work.
 
 ## Android device
 


### PR DESCRIPTION
As of Crosswalk 20 which has recently been promoted to the stable
channel, Crosswalk no longer supports Android 4.0, so update the
instructions and mention 4.1+.