### PR TITLE
Remove "basicAuth" from harp.json.

### DIFF
--- a/harp.json
+++ b/harp.json
@@ -6,7 +6,6 @@
     "name":        "Crosswalk",
     "email":       "",
     "url":         "http://crosswalk-project.org",
-    "basicAuth":   "crosswalk:chloi",
     "service": {
       "analytics": false,
       "tagManager": "GTM-WC843Q",


### PR DESCRIPTION
It is not used in production, but it still makes sense to remove entries
containing passwords from the tree.