### PR TITLE
Fix typos in gclient config instructions

### DIFF
--- a/public/contribute/building_crosswalk/linux_build.md
+++ b/public/contribute/building_crosswalk/linux_build.md
@@ -41,7 +41,7 @@ There are two ways to define those flags:
    from. It assumes `depot_tools` is in your `PATH` variable.
 
     ```
-    gclient config --name src/xwalk https://github.com/crosswalk-project/crossswalk.git
+    gclient config --name src/xwalk https://github.com/crosswalk-project/crosswalk.git
     ```
 
 1. Run `gclient sync` to fetch Crosswalk, all other git repositories it depends

--- a/public/contribute/building_crosswalk/windows_build.md
+++ b/public/contribute/building_crosswalk/windows_build.md
@@ -94,7 +94,7 @@ look like this:
    from. It assumes `depot_tools` is in your `PATH` variable.
 
     ```
-    gclient config --name src/xwalk https://github.com/crosswalk-project/crossswalk.git
+    gclient config --name src/xwalk https://github.com/crosswalk-project/crosswalk.git
     ```
 
 1. Run `gclient sync` to fetch Crosswalk, all other git repositories it depends


### PR DESCRIPTION
The git repository is called "crosswalk", not "crossswalk".

BUG=XWALK-7345
BUG=XWALK-7382