### PR TITLE
android build: Rename some sections to avoid confusion

### DIFF
--- a/public/contribute/building_crosswalk/android_build.md
+++ b/public/contribute/building_crosswalk/android_build.md
@@ -49,7 +49,7 @@ Note that at the moment it is **not** possible to target multiple architectures
 in a single build: if you want to build for both ARM and x86, you need to have
 two separate builds.
 
-## Fetching the source code
+## All versions: fetching the source code
 
 1. Before calling `gclient sync` below, you have to set the `XWALK_OS_ANDROID`
    environment variable so that all Android-specific git repositories are
@@ -93,7 +93,7 @@ two separate builds.
     them is covered in a later section, after which you can run `gyp_xwalk`
     manually again.
 
-## Dependency installation
+## All versions: dependency installation
 
 The Crosswalk for Android build requires several packages to be present on your
 Linux installation. All dependencies are checked for at configuration time --


### PR DESCRIPTION
The organization of the sections in this page has confused more than one
person: they assume "Fetching the source code" and "Dependency
installation" are subsections of "Crosswalk 22 and earlier", while they
are actually at the same level and must be run regardless of the
Crosswalk version the user wants to build.

Moving them to another location isn't really an option, as those
instructions should be followed in the current order. Add an "all
versions" to those 2 sections to make it more clear that they apply to
all Crosswalk versions.
