### PR TITLE
building crosswalk: Move gyp instructions to the end of each page

### DIFF
--- a/public/contribute/building_crosswalk/android_build.md
+++ b/public/contribute/building_crosswalk/android_build.md
@@ -11,43 +11,14 @@ These instructions assume you have already downloaded `depot_tools` and that it
 is in your `PATH` environment variable. See the
 [prerequisites](prerequisites.html) page for further information.
 
-## Crosswalk 22 and earlier: gyp setup
+## Configure gyp
 
-Up to Crosswalk 22, both Chromium and Crosswalk used gyp as a meta-build system
-that generated the actual build system files used by ninja.
+Older (< 23) Crosswalk versions are based on Chromium releases that use gyp as
+their meta-build system.
 
-gyp accepts flags to change its behavior, and you **must** set some of those
-flags in order to create an Android build.
-
-There are two ways to define those flags:
-
-1. Create a file called `chromium.gyp_env` on the directory where you will
-   later call `gclient config` and `gclient sync` (so the one above `src/`).
-   It needs to look like this:
-
-    ```
-    {
-      'GYP_DEFINES': 'key1=value1 key2=value2',
-    }
-    ```
-
-1. Using `export` in your shell to set the `GYP_DEFINES` environment variable.
-
-The very least you need to add to your `GYP_DEFINES` is `OS=android`. The
-default build will target 32-bit ARM; if you want to target a different
-architecture, you must also set the `target_arch` variable to `ia32`, `x64` or
-`arm64`. For example, if you are using `chromium.gyp_env`, it should look like
-this to create an Android build for 64-bit Intel processors.
-
-```
-{
-  'GYP_DEFINES': 'OS=android target_arch=x64',
-}
-```
-
-Note that at the moment it is **not** possible to target multiple architectures
-in a single build: if you want to build for both ARM and x86, you need to have
-two separate builds.
+If you want to build one of those versions, you _must_ follow the section
+**Crosswalk 22 and earlier: gyp setup** at the end of this page before
+proceeding.
 
 ## Fetching the source code
 
@@ -152,6 +123,44 @@ of the time, this will be done automatically for you when building).
 See Chromium's
 [page about GN](https://www.chromium.org/developers/gn-build-configuration) for
 more information, including other common settings.
+
+## Crosswalk 22 and earlier: gyp setup
+
+Up to Crosswalk 22, both Chromium and Crosswalk used gyp as a meta-build system
+that generated the actual build system files used by ninja.
+
+gyp accepts flags to change its behavior, and you **must** set some of those
+flags in order to create an Android build.
+
+There are two ways to define those flags:
+
+1. Create a file called `chromium.gyp_env` on the directory where you will
+   later call `gclient config` and `gclient sync` (so the one above `src/`).
+   It needs to look like this:
+
+    ```
+    {
+      'GYP_DEFINES': 'key1=value1 key2=value2',
+    }
+    ```
+
+1. Using `export` in your shell to set the `GYP_DEFINES` environment variable.
+
+The very least you need to add to your `GYP_DEFINES` is `OS=android`. The
+default build will target 32-bit ARM; if you want to target a different
+architecture, you must also set the `target_arch` variable to `ia32`, `x64` or
+`arm64`. For example, if you are using `chromium.gyp_env`, it should look like
+this to create an Android build for 64-bit Intel processors.
+
+```
+{
+  'GYP_DEFINES': 'OS=android target_arch=x64',
+}
+```
+
+Note that at the moment it is **not** possible to target multiple architectures
+in a single build: if you want to build for both ARM and x86, you need to have
+two separate builds.
 
 ## Building Crosswalk
 

--- a/public/contribute/building_crosswalk/linux_build.md
+++ b/public/contribute/building_crosswalk/linux_build.md
@@ -8,24 +8,15 @@ is in your `PATH` environment variable. See the
 
 Additionally, you are expected to be using a 64-bit Linux installation.
 
-## Crosswalk 22 and earlier: gyp setup
+## Configure gyp
 
-Up to Crosswalk 22, both Chromium and Crosswalk used gyp as a meta-build system
-that generated the actual build system files used by ninja. gyp accepts flags to change its behavior.
+Older (< 23) Crosswalk versions are based on Chromium releases that use gyp as
+their meta-build system.
 
-There are two ways to define those flags:
-
-1. Create a file called `chromium.gyp_env` on the directory where you will
-   later call `gclient config` and `gclient sync` (so the one above `src/`).
-   It needs to look like this:
-
-    ```
-    {
-      'GYP_DEFINES': 'key1=value1 key2=value2',
-    }
-    ```
-
-1. Using `export` in your shell to set the `GYP_DEFINES` environment variable.
+If you want to build one of those versions, make sure you follow the gyp setup
+in the section **Crosswalk 22 and earlier: gyp setup** at the end of this page
+if you would like to build for a different CPU architecture or adjust any build
+parameters.
 
 ## Fetching the source code
 
@@ -113,6 +104,45 @@ of the time, this will be done automatically for you when building).
 See Chromium's
 [page about GN](https://www.chromium.org/developers/gn-build-configuration) for
 more information, including other common settings.
+
+## Crosswalk 22 and earlier: gyp setup
+
+Up to Crosswalk 22, both Chromium and Crosswalk used gyp as a meta-build system
+that generated the actual build system files used by ninja.
+
+gyp accepts flags to change its behavior. They can be used to tell it you want
+to create a 32-bit build, for example.
+
+There are two ways to define those flags:
+
+1. Create a file called `chromium.gyp_env` on the directory where you will
+   later call `gclient config` and `gclient sync` (so the one above `src/`).
+   It needs to look like this:
+
+    ```
+    {
+      'GYP_DEFINES': 'key1=value1 key2=value2',
+    }
+    ```
+
+1. Use `export` in your shell to set the `GYP_DEFINES` environment variable.
+
+These values are read every time you run the `src/xwalk/gyp_xwalk` script, so
+whenever you want to change them remember to run the script afterwards.
+
+To generate a 32-bit build instead of a 64-bit one, you can set `target_arch`
+to `x86`. For example, if you are using `chromium.gyp_env`, its contents should
+look like this:
+
+```
+{
+  'GYP_DEFINES': 'target_arch=x86,
+}
+```
+
+Do not forget to run `src/xwalk/gyp_xwalk` (it is run automatically with
+`gclient sync`) whenever you modify your gyp flags, otherwise your changes will
+have no effect.
 
 ## Building Crosswalk
 

--- a/public/contribute/building_crosswalk/windows_build.md
+++ b/public/contribute/building_crosswalk/windows_build.md
@@ -44,41 +44,15 @@ while the second will set it for all future prompts.
 See the [prerequisites](prerequisites.html) section if you prefer to configure
 those environment variables using a GUI.
 
-## Crosswalk 22 and earlier: gyp setup
+## Configure gyp
 
-Up to Crosswalk 22, both Chromium and Crosswalk used gyp as a meta-build system
-that generated the actual build system files used by ninja.
+Older (< 23) Crosswalk versions are based on Chromium releases that use gyp as
+their meta-build system.
 
-gyp accepts flags to change its behavior. They can be used to tell it you want
-to create a 64-bit build, for example.
-
-There are two ways to define those flags:
-
-1. Create a file called `chromium.gyp_env` on the directory where you will
-   later call `gclient config` and `gclient sync` (so the one above `src/`).
-   It needs to look like this:
-
-    ```
-    {
-      'GYP_DEFINES': 'key1=value1 key2=value2',
-    }
-    ```
-
-1. Use `set` and/or `setx` in a command prompt to set `GYP_DEFINES` as an
-   environment variable.
-
-These values are read every time you run the `src/xwalk/gyp_xwalk` script, so
-whenever you want to change them remember to run the script afterwards.
-
-To generate a 64-bit build instead of a 32-bit one, you can set `target_arch`
-to `x64`. For example, if you are using `chromium.gyp_env`, its contents should
-look like this:
-
-```
-{
-  'GYP_DEFINES': 'target_arch=x64',
-}
-```
+If you want to build one of those versions, make sure you follow the gyp setup
+in the section **Crosswalk 22 and earlier: gyp setup** at the end of this page
+if you would like to build for a different CPU architecture or adjust any build
+parameters.
 
 ## Fetching the source code
 
@@ -139,6 +113,46 @@ of the time, this will be done automatically for you when building).
 See Chromium's
 [page about GN](https://www.chromium.org/developers/gn-build-configuration) for
 more information, including other common settings.
+
+## Crosswalk 22 and earlier: gyp setup
+
+Up to Crosswalk 22, both Chromium and Crosswalk used gyp as a meta-build system
+that generated the actual build system files used by ninja.
+
+gyp accepts flags to change its behavior. They can be used to tell it you want
+to create a 64-bit build, for example.
+
+There are two ways to define those flags:
+
+1. Create a file called `chromium.gyp_env` on the directory where you will
+   later call `gclient config` and `gclient sync` (so the one above `src/`).
+   It needs to look like this:
+
+    ```
+    {
+      'GYP_DEFINES': 'key1=value1 key2=value2',
+    }
+    ```
+
+1. Use `set` and/or `setx` in a command prompt to set `GYP_DEFINES` as an
+   environment variable.
+
+These values are read every time you run the `src\xwalk\gyp_xwalk` script, so
+whenever you want to change them remember to run the script afterwards.
+
+To generate a 64-bit build instead of a 32-bit one, you can set `target_arch`
+to `x64`. For example, if you are using `chromium.gyp_env`, its contents should
+look like this:
+
+```
+{
+  'GYP_DEFINES': 'target_arch=x64',
+}
+```
+
+Do not forget to run `src\xwalk\gyp_xwalk` (it is run automatically with
+`gclient sync`) whenever you modify your gyp flags, otherwise your changes will
+have no effect.
 
 ## Building Crosswalk
 


### PR DESCRIPTION
More than one person was confused by our build instructions and thought
"fetching the source code" and "dependency installation" were
subsections of "Crosswalk 22 and earlier", while they are in fact all at
the same level.

Since gyp is deprecated, move that section to the bottom of each page
and just mention it at the beginning so that people wanting to build
older Crosswalk releases can follow the right instructions.
