### PR TITLE
Add project closure message to front page

### DIFF
--- a/public/index.ejs
+++ b/public/index.ejs
@@ -29,6 +29,7 @@
         <a class="button-follower" id="main-follow-twitter-button" href="http://twitter.com/xwalk_project">
           <img src="/assets/Twitter_logo_white.png" width="20px" /> Follow the Crosswalk Project on Twitter
         </a>
+              <p><strong>Important: </strong>This project is not maintained anymore. The last Crosswalk release was Crosswalk 23. Read more in this <a href="https://crosswalk-project.org/blog/crosswalk-final-release.html">announcement</a></p> 
      </div>
     </div>
   </div>


### PR DESCRIPTION
Add a notice to the beginning of the front page so that the status of the project is clear.