### PR TITLE
building crosswalk: Fix Android target names.

### DIFF
--- a/public/contribute/building_crosswalk/android_build.md
+++ b/public/contribute/building_crosswalk/android_build.md
@@ -169,7 +169,7 @@ Crosswalk.
 
 ```
 cd C:\path\to\crosswalk-checkout\src
-ninja -C YOUR-BUILD-DIR xwalk
+ninja -C YOUR-BUILD-DIR YOUR-TARGET
 ```
 
 You should replace **YOUR-BUILD-DIR** above with the appropriate directory


### PR DESCRIPTION
Do not hardcode "xwalk" like we do for other platforms, as the target names
in Android are different. Fixes crosswalk-project/crosswalk#4002.